### PR TITLE
Support --max-old-space-size node argument

### DIFF
--- a/bin/mocha
+++ b/bin/mocha
@@ -61,6 +61,7 @@ process.argv.slice(2).forEach(function(arg){
       break;
     default:
       if (0 == arg.indexOf('--trace')) args.unshift(arg);
+      else if (0 == arg.indexOf('--max-old-space-size')) args.unshift(arg);
       else args.push(arg);
       break;
   }


### PR DESCRIPTION
This is useful to get tests which require large heaps working.
